### PR TITLE
Bugfix de javascript en js_minimized_jet()

### DIFF
--- a/paytpv.php
+++ b/paytpv.php
@@ -957,13 +957,17 @@ class Paytpv extends PaymentModule {
 		}).call(this);
 
 		$(document).ready(function() {
+			var oldLength = 0;
 			$('#expiry_date').on('input',function(){
 				var curLength = $(this).val().length;
-				if(curLength === 2){
-					var newInput = $(this).val();
-					newInput += '/';
-					$(this).val(newInput);
-				}
+	        if(!$(this).val().match(/[/]/)) {
+	          if((curLength === 2) && (oldLength<curLength) ){
+	            var newInput = $(this).val();
+	            newInput += '/';
+	            $(this).val(newInput);
+	          }
+	        }
+        	oldLength = curLength;
 			});
 		})";
 		return Minifier::minify($js_code);


### PR DESCRIPTION
Corrección del codigo javascript de autoinserción del separador de meses y años en el campo expiry_date que tenia un comportamiento erróneo al borrar con teclado (backspace). Ahora evita que se inserten separadores suplementarios, y permite borrar la fecha entera en caso de error.